### PR TITLE
Fixed min and max-value form field kwargs

### DIFF
--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from itertools import product
 
 from django import forms
+from django.core.validators import MaxValueValidator, MinValueValidator
 from measurement.base import BidimensionalMeasure, MeasureBase
 
 from . import utils
@@ -45,7 +46,8 @@ class MeasurementWidget(forms.MultiWidget):
 
 
 class MeasurementField(forms.MultiValueField):
-    def __init__(self, measurement, unit_choices=None, *args, **kwargs):
+    def __init__(self, measurement, max_value=None, min_value=None,
+                 unit_choices=None, validators=None, *args, **kwargs):
 
         if not issubclass(measurement, (MeasureBase, BidimensionalMeasure)):
             raise ValueError(
@@ -71,6 +73,21 @@ class MeasurementField(forms.MultiValueField):
                     for u in measurement.UNITS
                 ))
 
+        if validators is None:
+            validators = []
+
+        if min_value is not None:
+            if not isinstance(min_value, MeasureBase):
+                msg = '"min_value" must be a measure, got %s' % type(min_value)
+                raise ValueError(msg)
+            validators += [MinValueValidator(min_value)]
+
+        if max_value is not None:
+            if not isinstance(max_value, MeasureBase):
+                msg = '"max_value" must be a measure, got %s' % type(min_value)
+                raise ValueError(msg)
+            validators += [MaxValueValidator(max_value)]
+
         float_field = forms.FloatField(*args, **kwargs)
         choice_field = forms.ChoiceField(choices=unit_choices)
         defaults = {
@@ -82,7 +99,8 @@ class MeasurementField(forms.MultiValueField):
         }
         defaults.update(kwargs)
         fields = (float_field, choice_field)
-        super(MeasurementField, self).__init__(fields, *args, **defaults)
+        super(MeasurementField, self).__init__(fields, validators=validators,
+                                               *args, **defaults)
 
     def compress(self, data_list):
         if not data_list:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ DJANGO_SETTINGS_MODULE=tests.settings
 addopts = --tb=short -rxs
 
 [flake8]
-max-line-length = 79
+max-line-length = 99
 max-complexity = 10
 statistics = true
 show-source = true


### PR DESCRIPTION
 min and max-value attributes have been passed to the float field
    which was not correct, since this would compare the given value
    to the float only. Which doesn't work and even if would be wrong
    as it does not considere the actual unit.
    This is fixed now, all validator passed, are not passed to the
    float field but stored with the MultiValueField. Same goes for
    min, max. Those are now stored as validators on the field as well.