### PR TITLE
unit_choices generated from .get_units(); LABELS attribute for unicode labels

### DIFF
--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -61,22 +61,19 @@ class MeasurementField(forms.MultiValueField):
                     (
                         '{0}__{1}'.format(primary, reference),
                         '{0}__{1}'.format(
-                            getattr(measurement.PRIMARY_DIMENSION,'LABELS',{}).get(primary,primary),
-                            getattr(measurement.REFERENCE_DIMENSION,'LABELS',{}).get(reference,reference)),
+                            getattr(measurement.PRIMARY_DIMENSION, 'LABELS', {}).get(
+                                primary, primary),
+                            getattr(measurement.REFERENCE_DIMENSION, 'LABELS', {}).get(
+                                reference, reference)),
                     )
                     for primary, reference in product(
                         measurement.PRIMARY_DIMENSION.get_units(),
                         measurement.REFERENCE_DIMENSION.get_units(),
                     )
                 ))
-                print list(product(
-                        measurement.PRIMARY_DIMENSION.get_units(),
-                        measurement.REFERENCE_DIMENSION.get_units(),
-                    ))
             else:
-                # TODO: make method for creating unicode labels in MeasureBase and use in BidimensionalMeasure
                 unit_choices = tuple((
-                    (u, getattr(measurement,'LABELS',{}).get(u,u))
+                    (u, getattr(measurement, 'LABELS', {}).get(u, u))
                     for u in measurement.get_units()
                 ))
 

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -60,17 +60,24 @@ class MeasurementField(forms.MultiValueField):
                 unit_choices = tuple((
                     (
                         '{0}__{1}'.format(primary, reference),
-                        '{0}__{1}'.format(primary, reference),
+                        '{0}__{1}'.format(
+                            getattr(measurement.PRIMARY_DIMENSION,'LABELS',{}).get(primary,primary),
+                            getattr(measurement.REFERENCE_DIMENSION,'LABELS',{}).get(reference,reference)),
                     )
                     for primary, reference in product(
-                        measurement.PRIMARY_DIMENSION.UNITS,
-                        measurement.REFERENCE_DIMENSION.UNITS,
+                        measurement.PRIMARY_DIMENSION.get_units(),
+                        measurement.REFERENCE_DIMENSION.get_units(),
                     )
                 ))
+                print list(product(
+                        measurement.PRIMARY_DIMENSION.get_units(),
+                        measurement.REFERENCE_DIMENSION.get_units(),
+                    ))
             else:
+                # TODO: make method for creating unicode labels in MeasureBase and use in BidimensionalMeasure
                 unit_choices = tuple((
-                    (u, u)
-                    for u in measurement.UNITS
+                    (u, getattr(measurement,'LABELS',{}).get(u,u))
+                    for u in measurement.get_units()
                 ))
 
         if validators is None:

--- a/docs/topics/forms.rst
+++ b/docs/topics/forms.rst
@@ -22,3 +22,21 @@ To limit the value choices of the MeasurementField uses the regular 'choices' ke
             choices=((1.0, 'one'), (2.0, 'two'))
         )
  
+If unicode symbols are needed in the labels for a MeasurementField, define a LABELS dictionary for your subclassed MeasureBase object::
+
+    # -*- coding: utf-8 -*-
+    from sympy import S, Symbol
+    
+    class Temperature(MeasureBase):
+        SU = Symbol('kelvin')
+        STANDARD_UNIT = 'k'
+        UNITS = {
+            'c': SU - S(273.15),
+            'f': (SU - S(273.15)) * S('9/5') + 32,
+            'k': 1.0
+        }
+        LABELS = {
+            'c':u'°C',
+            'f':u'°F',
+            'k':u'°K',
+        }

--- a/tests/custom_measure_base.py
+++ b/tests/custom_measure_base.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from sympy import S, Symbol
+from measurement.base import MeasureBase, BidimensionalMeasure
+
+__all__ = [
+    'Temperature',
+    'Time',
+    'DegreePerTime',
+]
+
+
+class Temperature(MeasureBase):
+    SU = Symbol('kelvin')
+    STANDARD_UNIT = 'k'
+    UNITS = {
+        'c': SU - S(273.15),
+        'f': (SU - S(273.15)) * S('9/5') + 32,
+        'k': 1.0
+    }
+    LABELS = {
+        'c': u'°C',
+        'f': u'°F',
+        'k': u'°K',
+    }
+
+
+class Time(MeasureBase):
+    UNITS = {
+        's': 3600.0,
+        'h': 1.0,
+    }
+    SI_UNITS = ['s']
+
+
+class DegreePerTime(BidimensionalMeasure):
+    PRIMARY_DIMENSION = Temperature
+    REFERENCE_DIMENSION = Time

--- a/tests/custom_measure_base.py
+++ b/tests/custom_measure_base.py
@@ -3,11 +3,11 @@
 from sympy import S, Symbol
 from measurement.base import MeasureBase, BidimensionalMeasure
 
-__all__ = [
+__all__ = (
     'Temperature',
     'Time',
     'DegreePerTime',
-]
+)
 
 
 class Temperature(MeasureBase):

--- a/tests/custom_measure_base.py
+++ b/tests/custom_measure_base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sympy import S, Symbol
-from measurement.base import MeasureBase, BidimensionalMeasure
+from measurement.base import BidimensionalMeasure, MeasureBase
 
 __all__ = (
     'Temperature',

--- a/tests/custom_measure_base.py
+++ b/tests/custom_measure_base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from sympy import S, Symbol
 from measurement.base import BidimensionalMeasure, MeasureBase
+from sympy import S, Symbol
 
 __all__ = (
     'Temperature',

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,9 +1,22 @@
 from django import forms
-
 from tests.models import MeasurementTestModel
+from django_measurement.forms import MeasurementField
+from .custom_measure_base import Temperature, Time, DegreePerTime
 
 
 class MeasurementTestForm(forms.ModelForm):
     class Meta:
         model = MeasurementTestModel
         exclude = []
+
+
+class LabelTestForm(forms.Form):
+    simple = MeasurementField(Temperature)
+
+
+class SITestForm(forms.Form):
+    simple = MeasurementField(Time)
+
+
+class BiDimensionalLabelTestForm(forms.Form):
+    simple = MeasurementField(DegreePerTime)

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -4,6 +4,7 @@ from django_measurement.forms import MeasurementField
 from tests.custom_measure_base import DegreePerTime, Temperature, Time
 from tests.models import MeasurementTestModel
 
+
 class MeasurementTestForm(forms.ModelForm):
     class Meta:
         model = MeasurementTestModel

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,8 +1,8 @@
 from django import forms
-from tests.models import MeasurementTestModel
-from django_measurement.forms import MeasurementField
-from .custom_measure_base import Temperature, Time, DegreePerTime
 
+from django_measurement.forms import MeasurementField
+from tests.custom_measure_base import DegreePerTime, Temperature, Time
+from tests.models import MeasurementTestModel
 
 class MeasurementTestForm(forms.ModelForm):
     class Meta:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -8,7 +8,12 @@ from measurement import measures
 from measurement.measures import Distance
 
 from django_measurement.forms import MeasurementField
-from tests.forms import MeasurementTestForm, LabelTestForm, SITestForm, BiDimensionalLabelTestForm
+from tests.forms import (
+    BiDimensionalLabelTestForm,
+    LabelTestForm, 
+    MeasurementTestForm, 
+    SITestForm,
+)
 from tests.models import MeasurementTestModel
 
 pytestmark = [

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,10 +9,7 @@ from measurement.measures import Distance
 
 from django_measurement.forms import MeasurementField
 from tests.forms import (
-    BiDimensionalLabelTestForm,
-    LabelTestForm, 
-    MeasurementTestForm, 
-    SITestForm,
+    BiDimensionalLabelTestForm, LabelTestForm, MeasurementTestForm, SITestForm
 )
 from tests.models import MeasurementTestModel
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 from django.core.exceptions import ValidationError
 from django.utils import module_loading
@@ -6,7 +8,7 @@ from measurement import measures
 from measurement.measures import Distance
 
 from django_measurement.forms import MeasurementField
-from tests.forms import MeasurementTestForm
+from tests.forms import MeasurementTestForm, LabelTestForm, SITestForm, BiDimensionalLabelTestForm
 from tests.models import MeasurementTestModel
 
 pytestmark = [
@@ -257,3 +259,17 @@ class TestMeasurementFormField(object):
         assert record.message == ('You assigned a float instead of Distance to'
                                   ' tests.models.MeasurementTestModel.measurement_distance,'
                                   ' unit was guessed to be "m".')
+
+    def test_unicode_labels(self):
+        form = LabelTestForm()
+        assert ('c', u'°C') in form.fields['simple'].fields[1].choices
+        assert ('f', u'°F') in form.fields['simple'].fields[1].choices
+        assert ('k', u'°K') in form.fields['simple'].fields[1].choices
+
+        si_form = SITestForm()
+        assert ('ms', 'ms') in si_form.fields['simple'].fields[1].choices
+        assert ('Ps', 'Ps') in si_form.fields['simple'].fields[1].choices
+
+        bi_dim_form = BiDimensionalLabelTestForm()
+        assert ('c__ms', u'°C__ms') in bi_dim_form.fields['simple'].fields[1].choices
+        assert ('c__Ps', u'°C__Ps') in bi_dim_form.fields['simple'].fields[1].choices


### PR DESCRIPTION
Made two changes for personal use that I think would benefit the library overall-
1. Populate a form's unit_choices via MeasureBase/BidimensionalMeasure's .get_units method instead of UNITS (allowing for population of measures generated via SI_UNITS).
2. If MeasureBase subclass has a LABELS attribute (dict of 'unit':u'unit_label') and unit in that attribute, create label for the specific option from that. This allows user to supply unicode labels without exceptions regardless of whether on Python 2 or 3.

Great lib, thanks!