### PR TITLE
Added bidimensional_separator setting/kwarg 

### DIFF
--- a/django_measurement/conf.py
+++ b/django_measurement/conf.py
@@ -9,6 +9,7 @@ __all__ = ('settings', 'DjangoMeasurementConf')
 
 
 class DjangoMeasurementConf(AppConf):
+
     """Settings for django-measurement."""
 
     BIDIMENSIONAL_SEPARATOR = '/'

--- a/django_measurement/conf.py
+++ b/django_measurement/conf.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Settings for django-measurement."""
+from __future__ import absolute_import, unicode_literals
+
+from appconf import AppConf
+from django.conf import settings  # NOQA
+
+__all__ = ('settings', 'DjangoMeasurementConf')
+
+
+class DjangoMeasurementConf(AppConf):
+    """Settings for django-measurement."""
+
+    BIDIMENSIONAL_SEPARATOR = '/'
+    """
+    For measurement classes subclassing a BidimensionalMeasure, this .
+    """

--- a/django_measurement/conf.py
+++ b/django_measurement/conf.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from appconf import AppConf
-from django.conf import settings  # NOQA
+from django.conf import settings
 
 __all__ = ('settings', 'DjangoMeasurementConf')
 
@@ -15,3 +15,6 @@ class DjangoMeasurementConf(AppConf):
     """
     For measurement classes subclassing a BidimensionalMeasure, this .
     """
+
+    class Meta:
+        prefix = 'measurement'

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -7,6 +7,7 @@ from django import forms
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from measurement.base import BidimensionalMeasure, MeasureBase
+from six import string_types
 
 from . import utils
 
@@ -60,8 +61,8 @@ class MeasurementField(forms.MultiValueField):
         self.measurement_class = measurement
         if not unit_choices:
             if issubclass(measurement, BidimensionalMeasure):
-                assert isinstance(bidimensional_separator, (unicode, str,)), \
-                    "Supplied bidimensional_separator for %s must be str or unicode instance;" \
+                assert isinstance(bidimensional_separator, string_types), \
+                    "Supplied bidimensional_separator for %s must be of string/unicode type;" \
                     " Instead got type %s" % (measurement, type(bidimensional_separator),)
                 unit_choices = tuple((
                     (

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -50,7 +50,7 @@ class MeasurementWidget(forms.MultiWidget):
 class MeasurementField(forms.MultiValueField):
     def __init__(self, measurement, max_value=None, min_value=None,
                  unit_choices=None, validators=None, 
-                 bidimensional_separator=getattr(settings,'BIDIMENSIONAL_SEPARATOR', '/'),
+                 bidimensional_separator=getattr(settings, 'BIDIMENSIONAL_SEPARATOR', '/'),
                  *args, **kwargs):
 
         if not issubclass(measurement, (MeasureBase, BidimensionalMeasure)):
@@ -63,7 +63,7 @@ class MeasurementField(forms.MultiValueField):
             if issubclass(measurement, BidimensionalMeasure):
                 assert isinstance(bidimensional_separator, string_types), \
                     "Supplied bidimensional_separator for %s must be of string/unicode type;" \
-                    " Instead got type %s" % (measurement, type(bidimensional_separator),)
+                    " Instead got type %s" % (measurement, str(type(bidimensional_separator)),)
                 unit_choices = tuple((
                     (
                         '{0}__{1}'.format(primary, reference),

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -52,7 +52,7 @@ class MeasurementField(forms.MultiValueField):
                  unit_choices=None, validators=None, 
                  bidimensional_separator=getattr(settings,'BIDIMENSIONAL_SEPARATOR', '/'),
                  *args, **kwargs):
-                     
+
         if not issubclass(measurement, (MeasureBase, BidimensionalMeasure)):
             raise ValueError(
                 "%s must be a subclass of MeasureBase" % measurement

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -10,6 +10,7 @@ from measurement.base import BidimensionalMeasure, MeasureBase
 from six import string_types
 
 from . import utils
+from .conf import settings
 
 
 class MeasurementWidget(forms.MultiWidget):
@@ -50,7 +51,7 @@ class MeasurementWidget(forms.MultiWidget):
 class MeasurementField(forms.MultiValueField):
     def __init__(self, measurement, max_value=None, min_value=None,
                  unit_choices=None, validators=None,
-                 bidimensional_separator=getattr(settings, 'BIDIMENSIONAL_SEPARATOR', '/'),
+                 bidimensional_separator=settings.BIDIMENSIONAL_SEPARATOR,
                  *args, **kwargs):
 
         if not issubclass(measurement, (MeasureBase, BidimensionalMeasure)):

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -49,7 +49,7 @@ class MeasurementWidget(forms.MultiWidget):
 class MeasurementField(forms.MultiValueField):
     def __init__(self, measurement, max_value=None, min_value=None,
                  unit_choices=None, validators=None, 
-                 bidimensional_seperator=getattr(settings,'BIDIMENSIONAL_SEPERATOR', '/'),
+                 bidimensional_separator=getattr(settings,'BIDIMENSIONAL_SEPARATOR', '/'),
                  *args, **kwargs):
                      
         if not issubclass(measurement, (MeasureBase, BidimensionalMeasure)):
@@ -60,16 +60,16 @@ class MeasurementField(forms.MultiValueField):
         self.measurement_class = measurement
         if not unit_choices:
             if issubclass(measurement, BidimensionalMeasure):
-                assert isinstance(bidimensional_seperator, (unicode, str,)), \
-                    "Supplied bidimensional_seperator for %s must be str or unicode instance;" \
-                    " Instead got type %s" % (measurement, type(bidimensional_seperator),)
+                assert isinstance(bidimensional_separator, (unicode, str,)), \
+                    "Supplied bidimensional_separator for %s must be str or unicode instance;" \
+                    " Instead got type %s" % (measurement, type(bidimensional_separator),)
                 unit_choices = tuple((
                     (
                         '{0}__{1}'.format(primary, reference),
                         '{0}{1}{2}'.format(
                             getattr(measurement.PRIMARY_DIMENSION, 'LABELS', {}).get(
                                 primary, primary),
-                            bidimensional_seperator,
+                            bidimensional_separator,
                             getattr(measurement.REFERENCE_DIMENSION, 'LABELS', {}).get(
                                 reference, reference)),
                     )

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -49,7 +49,7 @@ class MeasurementWidget(forms.MultiWidget):
 
 class MeasurementField(forms.MultiValueField):
     def __init__(self, measurement, max_value=None, min_value=None,
-                 unit_choices=None, validators=None, 
+                 unit_choices=None, validators=None,
                  bidimensional_separator=getattr(settings, 'BIDIMENSIONAL_SEPARATOR', '/'),
                  *args, **kwargs):
 

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -8,7 +8,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from measurement.base import BidimensionalMeasure, MeasureBase
 from six import string_types
 
-from . import utils
+from django_measurement import utils
 from django_measurement.conf import settings
 
 

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -4,13 +4,12 @@ from __future__ import absolute_import, unicode_literals
 from itertools import product
 
 from django import forms
-from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from measurement.base import BidimensionalMeasure, MeasureBase
 from six import string_types
 
 from . import utils
-from .conf import settings
+from django_measurement.conf import settings
 
 
 class MeasurementWidget(forms.MultiWidget):
@@ -51,7 +50,7 @@ class MeasurementWidget(forms.MultiWidget):
 class MeasurementField(forms.MultiValueField):
     def __init__(self, measurement, max_value=None, min_value=None,
                  unit_choices=None, validators=None,
-                 bidimensional_separator=settings.BIDIMENSIONAL_SEPARATOR,
+                 bidimensional_separator=settings.MEASUREMENT_BIDIMENSIONAL_SEPARATOR,
                  *args, **kwargs):
 
         if not issubclass(measurement, (MeasureBase, BidimensionalMeasure)):

--- a/docs/topics/forms.rst
+++ b/docs/topics/forms.rst
@@ -40,3 +40,14 @@ If unicode symbols are needed in the labels for a MeasurementField, define a LAB
             'f':u'°F',
             'k':u'°K',
         }
+        
+For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR=' per '`) or override at the kwarg level. 
+
+        speed = MeasurementField(
+            measurement=Speed,
+            bidimensional_separator=' per '
+        )
+        
+        # Rendered form label will now be in the format "ft per s", "m per hr", etc
+
+

--- a/docs/topics/forms.rst
+++ b/docs/topics/forms.rst
@@ -41,7 +41,7 @@ If unicode symbols are needed in the labels for a MeasurementField, define a LAB
             'k':u'°K',
         }
         
-For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR='/'` is default) or override at the kwarg level::
+For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR is '/'` by default, add setting to override for all BiDimensionalMeasure subclasses) or override for an individual field with the kwarg bidimensional_separator::
 
         speed = MeasurementField(
             measurement=Speed,

--- a/docs/topics/forms.rst
+++ b/docs/topics/forms.rst
@@ -41,11 +41,11 @@ If unicode symbols are needed in the labels for a MeasurementField, define a LAB
             'k':u'°K',
         }
         
-For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR=' per '`) or override at the kwarg level::
+For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR='/'` is default) or override at the kwarg level::
 
         speed = MeasurementField(
             measurement=Speed,
             bidimensional_separator=' per '
         )
         
-        # Rendered form label will now be in the format "ft per s", "m per hr", etc
+        # Rendered option labels will now be in the format "ft per s", "m per hr", etc

--- a/docs/topics/forms.rst
+++ b/docs/topics/forms.rst
@@ -41,7 +41,7 @@ If unicode symbols are needed in the labels for a MeasurementField, define a LAB
             'k':u'°K',
         }
         
-For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR is '/'` by default, add setting to override for all BiDimensionalMeasure subclasses) or override for an individual field with the kwarg bidimensional_separator::
+For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`MEASUREMENT_BIDIMENSIONAL_SEPARATOR is '/'` by default, add setting to override for all BiDimensionalMeasure subclasses) or override for an individual field with the kwarg bidimensional_separator::
 
         speed = MeasurementField(
             measurement=Speed,

--- a/docs/topics/forms.rst
+++ b/docs/topics/forms.rst
@@ -41,7 +41,7 @@ If unicode symbols are needed in the labels for a MeasurementField, define a LAB
             'k':u'°K',
         }
         
-For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR=' per '`) or override at the kwarg level. 
+For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set the separator either in settings.py (`BIDIMENSIONAL_SEPARATOR=' per '`) or override at the kwarg level::
 
         speed = MeasurementField(
             measurement=Speed,
@@ -49,5 +49,3 @@ For a `MeasurementField` that represents a `BidimensionalMeasure`, you can set t
         )
         
         # Rendered form label will now be in the format "ft per s", "m per hr", etc
-
-

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -3,24 +3,10 @@ Settings
 ========
 
 
-``MEASURE_OVERRIDES``
----------------------
-
-If you have your own measures to add, 
-you can specify a name for your measure and a string class path to allow
-for your custom measure to be properly stored and resurrected.::
-
-    MEASURE_OVERRIDES = {
-        'IU': 'path.to.my.class.IUMeasure'
-    }
-
-You can also override existing measure classes this way.
-
-
-``BIDIMENSIONAL_SEPARATOR``
+``MEASUREMENT_BIDIMENSIONAL_SEPARATOR``
 ---------------------
 For any BidimensionalMeasure, what is placed between the primary and reference dimensions on rendered label
 
-    BIDIMENSIONAL_SEPARATOR = " per "
+    MEASUREMENT_BIDIMENSIONAL_SEPARATOR = " per "
 
 Defaults to "/". Can be overriden as kwarg `bidimensional_separator` for a given MeasurementField.

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -2,6 +2,7 @@
 Settings
 ========
 
+
 ``MEASURE_OVERRIDES``
 ---------------------
 
@@ -14,3 +15,12 @@ for your custom measure to be properly stored and resurrected.::
     }
 
 You can also override existing measure classes this way.
+
+
+``BIDIMENSIONAL_SEPERATOR``
+---------------------
+For any BidimensionalMeasure, what is placed between the primary and reference dimensions on rendered label
+
+    BIDIMENSIONAL_SEPERATOR = " per "
+
+Defaults to "/". Can be overriden as kwarg `bidimensional_seperator` for a given MeasurementField.

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -17,10 +17,10 @@ for your custom measure to be properly stored and resurrected.::
 You can also override existing measure classes this way.
 
 
-``BIDIMENSIONAL_SEPERATOR``
+``BIDIMENSIONAL_SEPARATOR``
 ---------------------
 For any BidimensionalMeasure, what is placed between the primary and reference dimensions on rendered label
 
-    BIDIMENSIONAL_SEPERATOR = " per "
+    BIDIMENSIONAL_SEPARATOR = " per "
 
-Defaults to "/". Can be overriden as kwarg `bidimensional_seperator` for a given MeasurementField.
+Defaults to "/". Can be overriden as kwarg `bidimensional_separator` for a given MeasurementField.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 #    pip-compile requirements-dev.in
 #
 -e .
+django-appconf>=1.0.2
 flake8==2.5.0
 isort==4.2.2
 mccabe==0.3.1             # via flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+django-appconf>=1.0.2
 measurement>=1.6

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -273,5 +273,5 @@ class TestMeasurementFormField(object):
         assert ('Ps', 'Ps') in si_form.fields['simple'].fields[1].choices
 
         bi_dim_form = BiDimensionalLabelTestForm()
-        assert ('c__ms', u'°C__ms') in bi_dim_form.fields['simple'].fields[1].choices
-        assert ('c__Ps', u'°C__Ps') in bi_dim_form.fields['simple'].fields[1].choices
+        assert ('c__ms', u'°C/ms') in bi_dim_form.fields['simple'].fields[1].choices
+        assert ('c__Ps', u'°C/Ps') in bi_dim_form.fields['simple'].fields[1].choices


### PR DESCRIPTION
Added bidimensional_seperator kwarg to MeasurementField. This changes the option label upon rendering. 

This can be defined two ways- 
1. Add a setting "BIDIMENSIONAL_SEPARATOR" to settings.py, which will be default unless kwarg is supplied.
2. Passing kwarg bidimensional_separator to instantiation of a particular MeasurementField. 
Example- if kwarg bidimensional_separator=' per ' you would get a label of 'kg per s'. Otherwise, a default of "/" will be used. 

Using this project for large-scale engineering applications, I had a need for each level of complexity provided, so hopefully it's useful to others. 

Set default value as "/", which means if someone has an existing BidimensionalMeasure representing speed, then unit labeled as "kg__s" in the past would now be labeled as "kg/s". This does not affect the attribute identifiers per measurement object (value of kg/s is still retrieved via `some_object.kg__s`).