### PR TITLE
Add serialization and deserialization support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
+dist: xenial
 language: python
 sudo: false
 cache: pip
-python: 3.6
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
 env:
   matrix:
   - DJANGO=111
-  - DJANGO=20
+  - DJANGO=22
   - DJANGO=master
-  - TOXENV=qa
-  - TOXENV=docs
 matrix:
   fast_finish: true
+  include:
+    - env: TOXENV=qa
+    - env: TOXENV=docs
   allow_failures:
   - env: DJANGO=master
 install:

--- a/django_measurement/models.py
+++ b/django_measurement/models.py
@@ -90,11 +90,30 @@ class MeasurementField(FloatField):
             original_unit=self.get_default_unit(),
         )
 
+    def value_to_string(self, obj):
+        value = self.value_from_object(obj)
+        if not isinstance(value, self.MEASURE_BASES):
+            return value
+        return '%s:%s' % (value.value, value.unit)
+
+    def deserialize_value_from_string(self, s: str):
+        parts = s.split(':', 1)
+        if len(parts) != 2:
+            return None
+        value, unit = float(parts[0]), parts[1]
+        measure = get_measurement(self.measurement, value=value, unit=unit)
+        return measure
+
     def to_python(self, value):
+
         if value is None:
             return value
         elif isinstance(value, self.MEASURE_BASES):
             return value
+        elif isinstance(value, str):
+            parsed = self.deserialize_value_from_string(value)
+            if parsed is not None:
+                return parsed
         value = super(MeasurementField, self).to_python(value)
 
         return_unit = self.get_default_unit()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{36}-dj{111,20,master},qa,docs
+envlist = py{36,37,38}-dj{111,22,master},qa,docs
 [testenv]
 deps=
     -rrequirements-dev.txt
     dj111: https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
-    dj20: https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django
+    dj22: https://github.com/django/django/archive/stable/2.2.x.tar.gz#egg=django
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 commands=
     coverage run --source=django_measurement -m 'pytest' \


### PR DESCRIPTION
This pull request is a suggest fix for #91. (fixes #91)

- It adds a `value_to_string` method to `MeasurementField` that is called whenever django attempts to serialize the value, instead of using `str(obj)`. In frontend, `str(obj)` is used.
- It adds an attempt at parsing a str value when the deserializer invokes the `to_python` method.
