### PR TITLE
Updated to allow optional use of decimals without breaking current implementations

### DIFF
--- a/django_measurement/conf.py
+++ b/django_measurement/conf.py
@@ -1,6 +1,7 @@
 """Settings for django-measurement."""
-from appconf import AppConf
 from django.conf import settings
+
+from appconf import AppConf
 
 __all__ = ('settings',)
 

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -3,10 +3,9 @@ from itertools import product
 from django import forms
 from django.core.validators import MaxValueValidator, MinValueValidator
 
+from django_measurement.conf import settings
+from django_measurement.utils import get_measurement
 from measurement.base import BidimensionalMeasure, MeasureBase
-
-from . import utils
-from .conf import settings
 
 
 class MeasurementWidget(forms.MultiWidget):
@@ -44,10 +43,19 @@ class MeasurementWidget(forms.MultiWidget):
         return [None, None]
 
 
+def get_number_field(max_digits, decimal_places, *args, **kwargs):
+    if max_digits is not None and decimal_places is not None:
+        return forms.DecimalField(max_digits=max_digits,
+                                  decimal_places=decimal_places,
+                                  *args, **kwargs)
+    else:
+        msg = 'Must specify both max_digits and decimal_places.'
+        raise ValueError(msg)
+
+
 class MeasurementField(forms.MultiValueField):
-    def __init__(self, measurement, max_value=None, min_value=None,
-                 unit_choices=None, validators=None, decimal=False,
-                 max_digits=None, decimal_places=None,
+    def __init__(self, measurement, max_value=None, min_value=None, unit_choices=None,
+                 validators=None, max_digits=None, decimal_places=None,
                  bidimensional_separator=settings.MEASUREMENT_BIDIMENSIONAL_SEPARATOR,
                  *args, **kwargs):
 
@@ -98,14 +106,7 @@ class MeasurementField(forms.MultiValueField):
                 raise ValueError(msg)
             validators += [MaxValueValidator(max_value)]
 
-        if decimal:
-            if max_digits is not None and decimal_places is not None:
-                number_field = forms.DecimalField(max_digits=max_digits, decimal_places=decimal_places, *args, **kwargs)
-            else:
-                msg = 'Must specify both max_digits and decimal_places when using decimals'
-                raise ValueError(msg)
-        else:
-            number_field = forms.FloatField(*args, **kwargs)
+        number_field = get_number_field(max_digits, decimal_places, *args, **kwargs)
 
         choice_field = forms.ChoiceField(choices=unit_choices)
         defaults = {
@@ -117,8 +118,7 @@ class MeasurementField(forms.MultiValueField):
         }
         defaults.update(kwargs)
         fields = (number_field, choice_field)
-        super().__init__(fields, validators=validators,
-                                               *args, **defaults)
+        super().__init__(fields, validators=validators, *args, **defaults)
 
     def compress(self, data_list):
         if not data_list:
@@ -128,7 +128,7 @@ class MeasurementField(forms.MultiValueField):
         if value in self.empty_values:
             return None
 
-        return utils.get_measurement(
+        return get_measurement(
             self.measurement_class,
             value,
             unit

--- a/django_measurement/models.py
+++ b/django_measurement/models.py
@@ -1,8 +1,13 @@
 import logging
 import warnings
+import decimal as decimal_class
 
-from django.db.models import FloatField
+from django.db.backends import utils
+from django.utils.functional import cached_property
+from django.core import checks, validators
+from django.db.models import Field, FloatField, DecimalField
 from django.utils.translation import ugettext_lazy as _
+
 from measurement import measures
 from measurement.base import BidimensionalMeasure, MeasureBase
 
@@ -12,8 +17,227 @@ from .utils import get_measurement
 logger = logging.getLogger('django_measurement')
 
 
-class MeasurementField(FloatField):
+class MeasurementDecimalField(Field):
     description = "Easily store, retrieve, and convert python measures."
+    empty_strings_allowed = False
+    MEASURE_BASES = (
+        BidimensionalMeasure,
+        MeasureBase,
+    )
+    default_error_messages = {
+        'invalid_type': _(
+            "'%(value)s' (%(type_given)s) value"
+            " must be of type %(type_wanted)s."
+        ),
+    }
+
+    def __init__(self, verbose_name=None, name=None, measurement=None,
+                 max_digits=None, decimal_places=None, decimal=True,
+                 measurement_class=None, unit_choices=None, *args, **kwargs):
+
+        if not measurement and measurement_class is not None:
+            warnings.warn(
+                "\"measurement_class\" will be removed in version 4.0",
+                DeprecationWarning
+            )
+            measurement = getattr(measures, measurement_class)
+
+        if not measurement:
+            raise TypeError('MeasurementField() takes a measurement'
+                            ' keyword argument. None given.')
+
+        if not issubclass(measurement, self.MEASURE_BASES):
+            raise TypeError(
+                'MeasurementField() takes a measurement keyword argument.'
+                ' It has to be a valid MeasureBase subclass.'
+            )
+
+        self.max_digits, self.decimal_places = max_digits, decimal_places
+        measurement.decimal = True
+        self.measurement = measurement
+        self.widget_args = {
+            'measurement': measurement,
+            'unit_choices': unit_choices,
+            'max_digits': max_digits,
+            'decimal_places': decimal_places,
+        }
+        
+        super().__init__(verbose_name, name, *args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs['decimal'] = True
+        if self.measurement is not None:
+            kwargs['measurement'] = self.measurement
+        if self.max_digits is not None:
+            kwargs['max_digits'] = self.max_digits
+        if self.decimal_places is not None:
+            kwargs['decimal_places'] = self.decimal_places
+        return name, path, args, kwargs
+
+    def get_prep_value(self, value):
+        if value is None:
+            return None
+
+        elif isinstance(value, self.MEASURE_BASES):
+            # sometimes we get sympy.core.numbers.Float, which the
+            # database does not understand, so explicitely convert to
+            # float
+
+            return decimal_class.Decimal(value.standard)
+
+        else:
+            return super().get_prep_value(value)
+
+    def get_default_unit(self):
+        unit_choices = self.widget_args['unit_choices']
+        if unit_choices:
+            return unit_choices[0][0]
+        return self.measurement.STANDARD_UNIT
+
+    def from_db_value(self, value, *args, **kwargs):
+        if value is None:
+            return None
+
+        return get_measurement(
+            measure=self.measurement,
+            value=value,
+            original_unit=self.get_default_unit(),
+            decimal=True
+        )
+
+    def value_to_string(self, obj):
+        value = self.value_from_object(obj)
+        if not isinstance(value, self.MEASURE_BASES):
+            return value
+        return '%s:%s' % (value.value, value.unit)
+
+    def deserialize_value_from_string(self, s: str):
+        parts = s.split(':', 1)
+        if len(parts) != 2:
+            return None
+        value, unit = decimal_class.Decimal(parts[0]), parts[1]
+        measure = get_measurement(self.measurement, value=value, unit=unit, decimal=True)
+        return measure
+
+    def to_python(self, value):
+
+        if value is None:
+            return value
+        elif isinstance(value, self.MEASURE_BASES):
+            return value
+        elif isinstance(value, str):
+            parsed = self.deserialize_value_from_string(value)
+            if parsed is not None:
+                return parsed
+        value = super().to_python(value)
+
+        return_unit = self.get_default_unit()
+
+        msg = "You assigned a %s instead of %s to %s.%s.%s, unit was guessed to be \"%s\"." % (
+            type(value).__name__,
+            str(self.measurement.__name__),
+            self.model.__module__,
+            self.model.__name__,
+            self.name,
+            return_unit,
+        )
+        logger.warning(msg)
+        return get_measurement(
+            measure=self.measurement,
+            value=value,
+            unit=return_unit,
+            decimal=True
+        )
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.MeasurementField, 'max_digits': self.max_digits, 'decimal_places': self.decimal_places,}
+        defaults.update(kwargs)
+        defaults.update(self.widget_args)
+        return super().formfield(**defaults)
+
+    def get_internal_type(self):
+        return "DecimalField"
+
+    @cached_property
+    def context(self):
+        return decimal_class.Context(prec=self.max_digits)    
+
+    def check(self, **kwargs):
+        errors = super().check(**kwargs)
+
+        digits_errors = [
+            *self._check_decimal_places(),
+            *self._check_max_digits(),
+        ]
+        if not digits_errors:
+            errors.extend(self._check_decimal_places_and_max_digits(**kwargs))
+        else:
+            errors.extend(digits_errors)
+        return errors
+
+    def _check_decimal_places(self):
+        try:
+            decimal_places = int(self.decimal_places)
+            if decimal_places < 0:
+                raise ValueError()
+        except TypeError:
+            return [
+                checks.Error(
+                    "DecimalFields must define a 'decimal_places' attribute.",
+                    obj=self,
+                    id='fields.E130',
+                )
+            ]
+        except ValueError:
+            return [
+                checks.Error(
+                    "'decimal_places' must be a non-negative integer.",
+                    obj=self,
+                    id='fields.E131',
+                )
+            ]
+        else:
+            return []
+
+    def _check_max_digits(self):
+        try:
+            max_digits = int(self.max_digits)
+            if max_digits <= 0:
+                raise ValueError()
+        except TypeError:
+            return [
+                checks.Error(
+                    "DecimalFields must define a 'max_digits' attribute.",
+                    obj=self,
+                    id='fields.E132',
+                )
+            ]
+        except ValueError:
+            return [
+                checks.Error(
+                    "'max_digits' must be a positive integer.",
+                    obj=self,
+                    id='fields.E133',
+                )
+            ]
+        else:
+            return []
+
+    def _check_decimal_places_and_max_digits(self, **kwargs):
+        if int(self.decimal_places) > int(self.max_digits):
+            return [
+                checks.Error(
+                    "'max_digits' must be greater or equal to 'decimal_places'.",
+                    obj=self,
+                    id='fields.E134',
+                )
+            ]
+        return []
+
+
+class MeasurementFloatField(FloatField):
+    description = _("Easily store, retrieve, and convert python measures.")
     empty_strings_allowed = False
     MEASURE_BASES = (
         BidimensionalMeasure,
@@ -52,11 +276,10 @@ class MeasurementField(FloatField):
             'unit_choices': unit_choices,
         }
 
-        super(MeasurementField, self).__init__(verbose_name, name,
-                                               *args, **kwargs)
+        super().__init__(verbose_name, name, *args, **kwargs)
 
     def deconstruct(self):
-        name, path, args, kwargs = super(MeasurementField, self).deconstruct()
+        name, path, args, kwargs = super().deconstruct()
         kwargs['measurement'] = self.measurement
         return name, path, args, kwargs
 
@@ -72,7 +295,7 @@ class MeasurementField(FloatField):
             return float(value.standard)
 
         else:
-            return super(MeasurementField, self).get_prep_value(value)
+            return super().get_prep_value(value)
 
     def get_default_unit(self):
         unit_choices = self.widget_args['unit_choices']
@@ -114,7 +337,7 @@ class MeasurementField(FloatField):
             parsed = self.deserialize_value_from_string(value)
             if parsed is not None:
                 return parsed
-        value = super(MeasurementField, self).to_python(value)
+        value = super().to_python(value)
 
         return_unit = self.get_default_unit()
 
@@ -137,4 +360,18 @@ class MeasurementField(FloatField):
         defaults = {'form_class': forms.MeasurementField}
         defaults.update(kwargs)
         defaults.update(self.widget_args)
-        return super(MeasurementField, self).formfield(**defaults)
+        return super().formfield(**defaults)
+
+class MeasurementField(object):
+    def __new__(self, verbose_name=None, name=None, measurement=None,
+                 measurement_class=None, unit_choices=None, decimal=False,
+                 max_digits=None, decimal_places=None, *args, **kwargs):
+
+
+        if decimal:
+            return MeasurementDecimalField(verbose_name=verbose_name, name=name, measurement=measurement,
+                 measurement_class=measurement_class, unit_choices=unit_choices, 
+                 max_digits=max_digits, decimal_places=decimal_places, *args, **kwargs)
+        else:
+            return MeasurementFloatField(verbose_name=verbose_name, name=name, measurement=measurement,
+                 measurement_class=measurement_class, unit_choices=unit_choices, *args, **kwargs)

--- a/django_measurement/utils.py
+++ b/django_measurement/utils.py
@@ -1,11 +1,13 @@
+#from measurement.base import BidimensionalMeasure
+
 from measurement.base import BidimensionalMeasure
 
 
-def get_measurement(measure, value, unit=None, original_unit=None):
+def get_measurement(measure, value, unit=None, original_unit=None, decimal=False):
     unit = unit or measure.STANDARD_UNIT
 
     m = measure(
-        **{unit: value}
+        **{unit: value}, decimal=decimal
     )
     if original_unit:
         m.unit = original_unit

--- a/django_measurement/utils.py
+++ b/django_measurement/utils.py
@@ -1,13 +1,11 @@
-#from measurement.base import BidimensionalMeasure
-
 from measurement.base import BidimensionalMeasure
 
 
-def get_measurement(measure, value, unit=None, original_unit=None, decimal=False):
+def get_measurement(measure, value, unit=None, original_unit=None):
     unit = unit or measure.STANDARD_UNIT
 
     m = measure(
-        **{unit: value}, decimal=decimal
+        **{unit: value}, decimal=True
     )
     if original_unit:
         m.unit = original_unit

--- a/docs/topics/storing.rst
+++ b/docs/topics/storing.rst
@@ -28,7 +28,9 @@ you'd add it to your log like so::
     beer.volume = Volume(us_pint=1)
     beer.save()
 
-    print beer # '1 us_pint of Total Domination'
+    print(beer)           # '1.0 us_pint of Total Domination'
+    print(beer.volume)    # '1.0 us_pint of Total Domination'
+    print(beer.volume.l)
 
 Perhaps you next recklessly dove into your stash of terrible,
 but nostalgia-inducing Russian beer and had a half-liter of
@@ -40,17 +42,51 @@ you'd add it to your log like so::
     another_beer.volume = Volume(l=0.5)
     another_beer.save()
 
-    print beer # '0.5 l of #9'
+    print(another_beer) # '0.5 l of #9'
 
 Note that although the original unit specified is stored for display,
 that the unit is abstracted to the measure's standard unit for storage and comparison::
 
-    print beer.volume                       # '1 us_pint'
-    print another_beer.volume               # '0.5 l'
-    print beer.volume > another_beer.volume # False
+    print(beer.volume)                       # '1 us_pint'
+    print(beer.volume.l)                     # '0.473176'
+    print(another_beer.volume.us_tsp)        # '101.44251252815029'
+    print(beer.volume > another_beer.volume) # False
+
+
+Optional Decimal use
+--------------------
+
+By default, django-measurement and python-measurement use float values for storing and 
+displaying measures. If you prefer deimals you can add the 'decimal', 'max_digits', and
+'decimal_places' arguments to the MeasurementField. The example above becomes::
+
+    from django_measurement.models import MeasurementField
+    from measurement.measures import Volume
+    from django.db import models
+
+    class BeerConsumptionLogEntry(models.Model):
+        name = models.CharField(max_length=255)
+        volume = MeasurementField(measurement=Volume, decimal=True, max_digits=12, decimal_places=20)
+
+        def __str__(self):
+            return '%s of %s' % (self.name, self.volume)
+
+    beer = BeerConsumptionLogEntry()
+    beer.name = 'Total Domination'
+    beer.volume = Volume(us_pint=1)
+    beer.save()
+
+    another_beer = BeerConsumptionLogEntry()
+    another_beer.name = '#9'
+    another_beer.volume = Volume(l=0.5)
+    another_beer.save()
+
+    print(beer.volume.value)                 # "Decimal('0.00047317600000000')""
+    print(another_beer.volume.value)         # "Decimal('0.00050000000000000')"
+    print(beer.volume > another_beer.volume) # False
 
 
 How is this data stored?
 ------------------------
 
-Since django-measurement v2.0 there value will be stored in a single float field.
+Since django-measurement v2.1 the value will be stored in a single float field or in a single decimal field if the optional decimal argument is utilized.

--- a/tests/custom_measure_base.py
+++ b/tests/custom_measure_base.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import BidimensionalMeasure, MeasureBase
 from sympy import S, Symbol
 
@@ -14,7 +16,7 @@ class Temperature(MeasureBase):
     UNITS = {
         'c': SU - S(273.15),
         'f': (SU - S(273.15)) * S('9/5') + 32,
-        'k': 1.0
+        'k': Decimal("1.0"),
     }
     LABELS = {
         'c': u'°C',
@@ -25,8 +27,8 @@ class Temperature(MeasureBase):
 
 class Time(MeasureBase):
     UNITS = {
-        's': 3600.0,
-        'h': 1.0,
+        's': Decimal("3600.0"),
+        'h': Decimal("1.0"),
     }
     SI_UNITS = ['s']
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,8 +1,8 @@
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from measurement import measures
 
 from django_measurement.models import MeasurementField
+from measurement import measures
 from tests.custom_measure_base import DegreePerTime, Temperature, Time
 
 
@@ -13,8 +13,10 @@ class MeasurementTestModel(models.Model):
             MinValueValidator(measures.Distance(mi=1.0)),
             MaxValueValidator(measures.Distance(mi=3.0))
         ],
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
+
     measurement_distance_km = MeasurementField(
         measurement=measures.Distance,
         unit_choices=(('km', 'km'),),
@@ -22,16 +24,18 @@ class MeasurementTestModel(models.Model):
             MinValueValidator(measures.Distance(km=1.0)),
             MaxValueValidator(measures.Distance(km=3.0))
         ],
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_weight = MeasurementField(
-        measurement=measures.Weight,
+        measurement=measures.Mass,
         validators=[
-            MinValueValidator(measures.Weight(kg=1.0)),
-            MaxValueValidator(measures.Weight(kg=3.0))
+            MinValueValidator(measures.Mass(kg=1.0)),
+            MaxValueValidator(measures.Mass(kg=3.0))
         ],
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_speed = MeasurementField(
@@ -40,7 +44,8 @@ class MeasurementTestModel(models.Model):
             MinValueValidator(measures.Speed(mph=1.0)),
             MaxValueValidator(measures.Speed(mph=3.0))
         ],
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_temperature = MeasurementField(
@@ -49,7 +54,8 @@ class MeasurementTestModel(models.Model):
             MinValueValidator(measures.Temperature(1.0)),
             MaxValueValidator(measures.Temperature(3.0))
         ],
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_temperature2 = MeasurementField(
@@ -58,7 +64,8 @@ class MeasurementTestModel(models.Model):
             MinValueValidator(measures.Temperature(1.0)),
             MaxValueValidator(measures.Temperature(3.0))
         ],
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_speed_mph = MeasurementField(
@@ -68,22 +75,26 @@ class MeasurementTestModel(models.Model):
             MinValueValidator(measures.Speed(mph=1.0)),
             MaxValueValidator(measures.Speed(mph=3.0))
         ],
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_custom_degree_per_time = MeasurementField(
         measurement=DegreePerTime,
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_custom_temperature = MeasurementField(
         measurement=Temperature,
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     measurement_custom_time = MeasurementField(
         measurement=Time,
-        blank=True, null=True,
+        blank=True, null=True, decimal=True, max_digits=20,
+        decimal_places=10
     )
 
     def __str__(self):


### PR DESCRIPTION
Split MeasurementField into two separate model fields in a way that is transparent to the end user.

This still works as normal, storing float values:

`volume = MeasurementField(measurement=Volume)`

But now you could also do this to store/retrieve Decimal values:

`volume = MeasurementField(measurement=Volume, decimal=True, max_digits=20, decimal_places=16)`

I haven't formatted this using black yet, since that was an issue on python-measurement.

Also updated print statements in docs, updated 'super' to the modern format, and added some extra info in the docs about this new feature.