### PR TITLE
Replace deprecated ugettext_lazy with gettext_lazy

### DIFF
--- a/django_measurement/models.py
+++ b/django_measurement/models.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 
 from django.db.models import FloatField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from measurement import measures
 from measurement.base import BidimensionalMeasure, MeasureBase
 


### PR DESCRIPTION
`ugettext_lazy` has been an alias for `gettext_lazy` since Django stopped supporting Python 2 in version 2.0 (see [source](https://github.com/django/django/blob/eb0f298e765ced5d52461ee8ec3fed8278b3d8d6/django/utils/translation/__init__.py#L139)).

Now it is also deprecated and produces a `RemovedInDjango40Warning`:
```
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```

See e.g. [this CI run](https://github.com/coddingtonbear/django-measurement/runs/2872823461?check_suite_focus=true).

This PR replaces `ugettext_lazy` with `gettext_lazy`.