### PR TITLE
Fix Django admin Measurement field save

### DIFF
--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -32,14 +32,17 @@ class MeasurementWidget(forms.MultiWidget):
 
     def decompress(self, value):
         if value:
-            choice_units = set([u for u, n in self.unit_choices])
+            if isinstance(value, str):
+                magnitude, unit = [v.strip() for v in value.split(' ')]
+                return [float(magnitude), unit]
+            elif isinstance(value, MeasureBase):
+                choice_units = set([u for u, n in self.unit_choices])
+                unit = value.STANDARD_UNIT
+                if unit not in choice_units:
+                    unit = choice_units.pop()
 
-            unit = value.STANDARD_UNIT
-            if unit not in choice_units:
-                unit = choice_units.pop()
-
-            magnitude = getattr(value, unit)
-            return [magnitude, unit]
+                magnitude = getattr(value, unit)
+                return [magnitude, unit]
 
         return [None, None]
 

--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -1,3 +1,4 @@
+import ast
 from itertools import product
 
 from django import forms
@@ -33,7 +34,14 @@ class MeasurementWidget(forms.MultiWidget):
     def decompress(self, value):
         if value:
             if isinstance(value, str):
-                magnitude, unit = [v.strip() for v in value.split(' ')]
+                try:
+                    literal_value = ast.literal_eval(value)
+                    magnitude, unit = literal_value
+                except:
+                    literal_value = value
+                    magnitude, unit = [
+                        v.strip() for v in literal_value.split(' ')
+                    ]
                 return [float(magnitude), unit]
             elif isinstance(value, MeasureBase):
                 choice_units = set([u for u, n in self.unit_choices])


### PR DESCRIPTION
Fixes #112 

Decompress can receive a `str` value. This PR checks if the value is a string or an instance of measurement class before processing and returning any values.