### PR TITLE
Enable use of measurement field in django admin

### DIFF
--- a/django_measurement/forms.py
+++ b/django_measurement/forms.py
@@ -32,6 +32,10 @@ class MeasurementWidget(forms.MultiWidget):
 
     def decompress(self, value):
         if value:
+            if isinstance(value, str):
+                instance = {str(value).split()[1]:str(value).split()[0]}
+                value = Weight(**instance)
+            
             choice_units = set([u for u, n in self.unit_choices])
 
             unit = value.STANDARD_UNIT


### PR DESCRIPTION
with this lines, we check if the value send from django admin is string, if it is, convert the value to an instance of measurement without affect anything else.